### PR TITLE
font-family:inherit für dropdown button

### DIFF
--- a/assets/css/dropdown.scss
+++ b/assets/css/dropdown.scss
@@ -57,6 +57,7 @@
         button {
           background-color: inherit;
           border: 0;
+          font-family: inherit;
           font-size: 1em;
           color: $link_color;
           padding: 0;


### PR DESCRIPTION
Andernfalls greift das Browser-Stylesheet und die Button-Darstellung weicht ab.