### PR TITLE
fix: use correct message for restoring messages

### DIFF
--- a/lib/cforum_web/controllers/messages/admin_controller.ex
+++ b/lib/cforum_web/controllers/messages/admin_controller.ex
@@ -21,7 +21,7 @@ defmodule CforumWeb.Messages.AdminController do
     Messages.restore_message(conn.assigns.current_user, conn.assigns.message)
 
     conn
-    |> put_flash(:info, gettext("Message was successfully deleted."))
+    |> put_flash(:info, gettext("Message was successfully restored."))
     |> redirect(to: ReturnUrl.return_path(conn, params, conn.assigns.thread))
   end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4088,9 +4088,13 @@ msgstr "Medaille erfolgreich gelöscht."
 
 #, elixir-format
 #: lib/cforum_web/controllers/messages/admin_controller.ex:16
-#: lib/cforum_web/controllers/messages/admin_controller.ex:24
 msgid "Message was successfully deleted."
 msgstr "Der Beitrag wurde erfolgreich gelöscht."
+
+#, elixir-format
+#: lib/cforum_web/controllers/messages/admin_controller.ex:24
+msgid "Message was successfully restored."
+msgstr "Der Beitrag wurde erfolgreich wiederhergestellt."
 
 #, elixir-format
 #: lib/cforum_web/templates/message/header_thread_icons_admin.html.eex:13

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -4067,8 +4067,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/cforum_web/controllers/messages/admin_controller.ex:16
-#: lib/cforum_web/controllers/messages/admin_controller.ex:24
 msgid "Message was successfully deleted."
+msgstr ""
+
+#, elixir-format
+#: lib/cforum_web/controllers/messages/admin_controller.ex:24
+msgid "Message was successfully restored."
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -4066,8 +4066,12 @@ msgstr ""
 
 #, elixir-format
 #: lib/cforum_web/controllers/messages/admin_controller.ex:16
-#: lib/cforum_web/controllers/messages/admin_controller.ex:24
 msgid "Message was successfully deleted."
+msgstr ""
+
+#, elixir-format
+#: lib/cforum_web/controllers/messages/admin_controller.ex:24
+msgid "Message was successfully restored."
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
Fixes #101 

Die diffs sehen soweit ganz gut aus; ich schätze die Zeilenenden passen jetzt.