### PR TITLE
Links im Header an die im Wiki angeglichen

### DIFF
--- a/lib/cforum_web/templates/layout/top_bar.html.eex
+++ b/lib/cforum_web/templates/layout/top_bar.html.eex
@@ -1,8 +1,8 @@
 <header class="cf-top-bar">
   <ul class="selflinks">
-    <li><%= link "SELFHTML", to: "https://wiki.selfhtml.org/wiki/SELFHTML:Verein" %></li>
-    <li><%= link "Wiki", to: "//wiki.selfhtml.org/" %></li>
+    <li><%= link "SELFHTML", to: "https://wiki.selfhtml.org/wiki/SELFHTML" %></li>
     <li><%= link "Forum", to: Path.root_url(@conn, :index) %></li>
     <li><%= link "Blog", to: Path.blog_url(@conn) %></li>
+    <li><%= link "Verein", to: "https://wiki.selfhtml.org/wiki/SELFHTML:Verein" %></li>
   </ul>
 </header>


### PR DESCRIPTION
Wie mit @matthias-scharwies und @Rolf-B besprochen, habe ich einmal die Reihenfolge der Links an die im Wiki angeglichen. Die CSS-Anpassungen sind davon unabhängig und folgen ggf. noch in einem weiteren PR.